### PR TITLE
Arbitrary Readers and Writers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 extern crate brainfuck;
 
-use std::env;
+use std::{io, env};
 use brainfuck::Interpreter;
 
 fn main() {
     let path = env::args().nth(1).unwrap();
-    Interpreter::from_file(&path).unwrap().run();
+    let mut stdin = io::stdin();
+    let mut stdout = io::stdout();
+    Interpreter::from_file(&path, &mut stdin, &mut stdout).unwrap().run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,5 +5,5 @@ use brainfuck::Interpreter;
 
 fn main() {
     let path = env::args().nth(1).unwrap();
-    Interpreter::load(&path).unwrap().run();
+    Interpreter::from_file(&path).unwrap().run();
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,22 +1,29 @@
 extern crate brainfuck;
+use std::io;
 use brainfuck::*;
+
 
 #[test]
 fn load() {
-    let interp = Interpreter::from_file("fixtures/hello.b");
+    let mut stdin = io::stdin();
+    let mut stdout = io::stdout();
+    let interp = Interpreter::from_file("fixtures/hello.b", &mut stdin, &mut stdout);
     assert!(interp.is_ok());
 }
 
 #[test]
 fn run() {
-    let mut interp = Interpreter::from_file("fixtures/hello.b").unwrap();
-    interp.run();
-    // TODO: Test something.
+    let mut stdin = io::stdin();
+    let mut stdout = Vec::new();
+    Interpreter::from_file("fixtures/hello.b", &mut stdin, &mut stdout).unwrap().run();
+    assert_eq!(String::from_utf8(stdout).unwrap(), "Hello World!\n");
 }
 
 #[test]
 fn run_with_callback() {
-    let mut interp = Interpreter::from_file("fixtures/hello.b").unwrap();
+    let mut stdin = io::stdin();
+    let mut stdout = io::stdout();
+    let mut interp = Interpreter::from_file("fixtures/hello.b", &mut stdin, &mut stdout).unwrap();
     let mut count = 0;
     interp.run_with_callback(|_| count = count + 1);
     assert_eq!(count, 907);
@@ -24,6 +31,8 @@ fn run_with_callback() {
 
 #[test]
 fn step() {
-    let mut interp = Interpreter::from_file("fixtures/hello.b").unwrap();
+    let mut stdin = io::stdin();
+    let mut stdout = io::stdout();
+    let mut interp = Interpreter::from_file("fixtures/hello.b", &mut stdin, &mut stdout).unwrap();
     assert!(interp.step().unwrap() == Instruction::SkipForward);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,20 +3,20 @@ use brainfuck::*;
 
 #[test]
 fn load() {
-    let interp = Interpreter::load("fixtures/hello.b");
+    let interp = Interpreter::from_file("fixtures/hello.b");
     assert!(interp.is_ok());
 }
 
 #[test]
 fn run() {
-    let mut interp = Interpreter::load("fixtures/hello.b").unwrap();
+    let mut interp = Interpreter::from_file("fixtures/hello.b").unwrap();
     interp.run();
     // TODO: Test something.
 }
 
 #[test]
 fn run_with_callback() {
-    let mut interp = Interpreter::load("fixtures/hello.b").unwrap();
+    let mut interp = Interpreter::from_file("fixtures/hello.b").unwrap();
     let mut count = 0;
     interp.run_with_callback(|_| count = count + 1);
     assert_eq!(count, 907);
@@ -24,6 +24,6 @@ fn run_with_callback() {
 
 #[test]
 fn step() {
-    let mut interp = Interpreter::load("fixtures/hello.b").unwrap();
+    let mut interp = Interpreter::from_file("fixtures/hello.b").unwrap();
     assert!(interp.step().unwrap() == Instruction::SkipForward);
 }


### PR DESCRIPTION
Currently the `Interpreter` only uses STDIN and STDOUT for the `.` and `,` instructions, however in the sake of flexibility it's better to allow other options as well. Now the interpreter can use anything that implements `Read` for `,` and anything that implements `Write` for `.`
