### PR TITLE
Pass a Mutable Reference to the Interpreter for the Hook

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,14 +227,14 @@ impl<'a> Interpreter<'a> {
     /// let mut reader = &[][..];
     /// let mut writer = Vec::<u8>::new();
     /// let mut interp = Interpreter::from_file("fixtures/hello.b", &mut reader, &mut writer).unwrap();
-    /// interp.run_with_callback(|i| {
-    ///     println!("Stepped: {}", i);
+    /// interp.run_with_callback(|interp, inst| {
+    ///     println!("Stepped: {}", inst);
     /// });
     /// ```
     pub fn run_with_callback<F>(&mut self, mut hook: F)
-    where F: FnMut(&Instruction) {
+    where F: FnMut(&mut Self, &Instruction) {
         while let Some(ref i) = self.step() {
-            hook(i);
+            hook(self, i);
         }
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -25,7 +25,7 @@ fn run_with_callback() {
     let mut stdout = io::stdout();
     let mut interp = Interpreter::from_file("fixtures/hello.b", &mut stdin, &mut stdout).unwrap();
     let mut count = 0;
-    interp.run_with_callback(|_| count = count + 1);
+    interp.run_with_callback(|_, _| count = count + 1);
     assert_eq!(count, 907);
 }
 


### PR DESCRIPTION
This allows for looking at the state of the interpreter, or changing it in a hook. I;'m not sure if we really want to be changing the state in a callback though. So maybe this should be an immutable reference.
