### PR TITLE
Failing Instructions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,12 +5,15 @@ use std::{error, fmt, io};
 pub enum Error {
     /// Errors with reading or writing to IO.
     Io(io::Error),
+    /// TODO: Is this the right name for this error.
+    InputEmpty,
 }
 
 impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Io(_) => "Io Error",
+            Error::InputEmpty => "Input Empty Error",
         }
     }
 }
@@ -19,6 +22,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Io(ref e) => e.fmt(f),
+            Error::InputEmpty => write!(f, "{}", error::Error::description(self)),
         }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -34,5 +34,5 @@ fn step() {
     let mut stdin = io::stdin();
     let mut stdout = io::stdout();
     let mut interp = Interpreter::from_file("fixtures/hello.b", &mut stdin, &mut stdout).unwrap();
-    assert!(interp.step().unwrap() == Instruction::SkipForward);
+    assert!(interp.step().unwrap().unwrap() == Instruction::SkipForward);
 }


### PR DESCRIPTION
An instruction's `execute` function now returns a `Result`. This allows us to indicate failure in instruction execution. Currently the only failing instructions are `.` and `,` which read and write to IO, which is not reliable.

This feature allows for other improvements as well. For example the wrapping logic from #2 can now be handled correctly, allowing for wrapping errors to be detected at runtime. This PR will need to be updated.

Last the type of the result is `Result<(), Error>` at the moment, but we could change it in the future to be `Result<Snapshot, Error>` for collecting a snapshot of the interpreter state. This is most useful for profiling as requested in #9.
