### PR TITLE
Tape

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
     InputEmpty,
     /// No program loaded.
     NoProgram,
+    /// Overflows.
+    Overflow,
 }
 
 impl error::Error for Error {
@@ -17,6 +19,7 @@ impl error::Error for Error {
             Error::Io(_) => "Io Error",
             Error::InputEmpty => "Input Empty Error",
             Error::NoProgram => "No Program",
+            Error::Overflow => "Overflow",
         }
     }
 }
@@ -27,6 +30,7 @@ impl fmt::Display for Error {
             Error::Io(ref e) => e.fmt(f),
             Error::InputEmpty => write!(f, "{}", error::Error::description(self)),
             Error::NoProgram => write!(f, "{}", error::Error::description(self)),
+            Error::Overflow => write!(f, "{}", error::Error::description(self)),
         }
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -105,7 +105,7 @@ impl<'a> Interpreter<'a> {
             Instruction::Output => {
                 // TODO: Handle errors.
                 // let byte = self.tape[self.ptr];
-                let byte = *self.tape.get_value();
+                let byte = self.tape.get_value();
                 try!(self.writer.write(&[byte]));
             },
             Instruction::Input => {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -95,15 +95,14 @@ impl<'a> Interpreter<'a> {
                 try!(self.tape.shift_value(-1));
             },
             Instruction::Output => {
-                let byte = self.tape.get();
-                try!(self.writer.write(&[byte]));
+                try!(self.writer.write(&[*self.tape]));
             },
             Instruction::Input => {
                 let input = try!(match self.reader.bytes().next() {
                     Some(b) => b,
                     None => return Err(Error::InputEmpty),
                 });
-                self.tape.set(input);
+                *self.tape = input;
             },
             Instruction::SkipForward(iptr) => {
                 if *self.tape == 0 {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -95,7 +95,7 @@ impl<'a> Interpreter<'a> {
                 try!(self.tape.shift_value(-1));
             },
             Instruction::Output => {
-                let byte = self.tape.get_value();
+                let byte = self.tape.get();
                 try!(self.writer.write(&[byte]));
             },
             Instruction::Input => {
@@ -103,7 +103,7 @@ impl<'a> Interpreter<'a> {
                     Some(b) => b,
                     None => return Err(Error::InputEmpty),
                 });
-                self.tape.set_value(input);
+                self.tape.set(input);
             },
             Instruction::SkipForward(iptr) => {
                 if *self.tape == 0 {
@@ -174,6 +174,7 @@ mod tests {
         interp.step().unwrap().unwrap().unwrap();
     }
 
+<<<<<<< d7beaf970a09bca2d0d037f047ff1d84f8621fd3
     #[test]
     fn ub_decrement_pointer_below_min() {
         // Decrementing the pointer below the start should wrap around to
@@ -242,4 +243,64 @@ mod tests {
         interp.load(program);
         assert!(interp.run().is_err());
     }
+=======
+    // #[test]
+    // fn ub_decrement_pointer_below_min() {
+    //     // Decrementing the pointer below the start should wrap around to
+    //     // the end of the tape.
+    //     let mut reader = &[][..];
+    //     let mut writer = Vec::<u8>::new();
+    //     {
+    //         let mut interp = Interpreter::new(&mut reader, &mut writer);
+    //         interp.load(Program::from_source("<."));
+    //         interp.run().unwrap();
+    //     }
+    //     assert_eq!(writer, [0]);
+    // }
+    //
+    // #[test]
+    // fn ub_increment_pointer_above_max() {
+    //     // Incrementing the pointer above the end should wrap around to
+    //     // the start of the tape. This test sets the first cell to 1,
+    //     // and then loops incrementing the pointer and subtracting 1
+    //     // from each cell until one of the cells is 0 (i.e.) the first
+    //     // cell. This relys on correctly working value wrapping.
+    //     let mut reader = &[][..];
+    //     let mut writer = Vec::<u8>::new();
+    //     {
+    //         let mut interp = Interpreter::new(&mut reader, &mut writer);
+    //         interp.load(Program::from_source("+[>-.]"));
+    //         interp.run().unwrap();
+    //     }
+    //     assert_eq!(writer.len(), 30000);
+    // }
+    //
+    // #[test]
+    // fn ub_decrement_value_below_min() {
+    //     // Decrementing a value below it's minimum value should wrap to
+    //     // it's maximum value.
+    //     let mut reader = &[][..];
+    //     let mut writer = Vec::<u8>::new();
+    //     {
+    //         let mut interp = Interpreter::new(&mut reader, &mut writer);
+    //         interp.load(Program::from_source("-."));
+    //         interp.run().unwrap();
+    //     }
+    //     assert_eq!(writer, [255]);
+    // }
+    //
+    // #[test]
+    // fn ub_increment_value_above_max() {
+    //     // Incrementing a value above it's maximum value should wrap to
+    //     // it's minimum value.
+    //     let mut reader = &[][..];
+    //     let mut writer = Vec::<u8>::new();
+    //     {
+    //         let mut interp = Interpreter::new(&mut reader, &mut writer);
+    //         interp.load(Program::from_source("+[+]."));
+    //         interp.run().unwrap();
+    //     }
+    //     assert_eq!(writer, [0]);
+    // }
+>>>>>>> Starting wrap checking.
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -83,16 +83,16 @@ impl<'a> Interpreter<'a> {
     fn execute(&mut self, instruction: Instruction) -> Result<(), Error> {
         match instruction {
             Instruction::IncPtr => {
-                try!(self.tape.shift_ptr(1));
+                self.tape >>= 1;
             },
             Instruction::DecPtr => {
-                try!(self.tape.shift_ptr(-1));
+                self.tape <<= 1;
             },
             Instruction::IncVal => {
-                try!(self.tape.shift_value(1));
+                self.tape += 1;
             },
             Instruction::DecVal => {
-                try!(self.tape.shift_value(-1));
+                self.tape -= 1;
             },
             Instruction::Output => {
                 try!(self.writer.write(&[*self.tape]));

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -103,7 +103,7 @@ impl<'a> Interpreter<'a> {
                     Some(b) => b,
                     None => return Err(Error::InputEmpty),
                 });
-                try!(self.tape.set_value(input));
+                self.tape.set_value(input);
             },
             Instruction::SkipForward(iptr) => {
                 if *self.tape == 0 {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -83,38 +83,26 @@ impl<'a> Interpreter<'a> {
     fn execute(&mut self, instruction: Instruction) -> Result<(), Error> {
         match instruction {
             Instruction::IncPtr => {
-                // let wrapped = (self.ptr as i16 + 1) % 30000;
-                // self.ptr = wrapped as usize;
                 try!(self.tape.shift_ptr(1));
             },
             Instruction::DecPtr => {
-                // let wrapped = (self.ptr as i16 - 1 + 30000) % 30000;
-                // self.ptr = wrapped as usize;
                 try!(self.tape.shift_ptr(-1));
             },
             Instruction::IncVal => {
-                // let wrapped = self.tape[self.ptr] as i16 + 1;
-                // self.tape[self.ptr] = wrapped as u8;
                 try!(self.tape.shift_value(1));
             },
             Instruction::DecVal => {
-                // let wrapped = self.tape[self.ptr] as i16 - 1;
-                // self.tape[self.ptr] = wrapped as u8;
                 try!(self.tape.shift_value(-1));
             },
             Instruction::Output => {
-                // TODO: Handle errors.
-                // let byte = self.tape[self.ptr];
                 let byte = self.tape.get_value();
                 try!(self.writer.write(&[byte]));
             },
             Instruction::Input => {
-                // TODO: Handle errors.
                 let input = try!(match self.reader.bytes().next() {
                     Some(b) => b,
                     None => return Err(Error::InputEmpty),
                 });
-                // self.tape[self.ptr] = input;
                 try!(self.tape.set_value(input));
             },
             Instruction::SkipForward(iptr) => {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -158,7 +158,7 @@ mod tests {
         let mut interp = Interpreter::new(&mut reader, &mut writer);
         interp.load(program);
         let mut count = 0;
-        assert!(interp.run_with_callback(|_| count = count + 1).is_ok());
+        assert!(interp.run_with_callback(|_, _| count = count + 1).is_ok());
         assert_eq!(count, 5);
     }
 
@@ -173,7 +173,6 @@ mod tests {
         interp.step().unwrap().unwrap().unwrap();
     }
 
-<<<<<<< d7beaf970a09bca2d0d037f047ff1d84f8621fd3
     #[test]
     fn ub_decrement_pointer_below_min() {
         // Decrementing the pointer below the start should wrap around to
@@ -237,69 +236,9 @@ mod tests {
     fn empty_io() {
         let mut reader = io::empty();
         let mut writer = Vec::<u8>::new();
-        let program = Program::from_source(",");
+        let program = Program::parse(",");
         let mut interp = Interpreter::new(&mut reader, &mut writer);
         interp.load(program);
         assert!(interp.run().is_err());
     }
-=======
-    // #[test]
-    // fn ub_decrement_pointer_below_min() {
-    //     // Decrementing the pointer below the start should wrap around to
-    //     // the end of the tape.
-    //     let mut reader = &[][..];
-    //     let mut writer = Vec::<u8>::new();
-    //     {
-    //         let mut interp = Interpreter::new(&mut reader, &mut writer);
-    //         interp.load(Program::from_source("<."));
-    //         interp.run().unwrap();
-    //     }
-    //     assert_eq!(writer, [0]);
-    // }
-    //
-    // #[test]
-    // fn ub_increment_pointer_above_max() {
-    //     // Incrementing the pointer above the end should wrap around to
-    //     // the start of the tape. This test sets the first cell to 1,
-    //     // and then loops incrementing the pointer and subtracting 1
-    //     // from each cell until one of the cells is 0 (i.e.) the first
-    //     // cell. This relys on correctly working value wrapping.
-    //     let mut reader = &[][..];
-    //     let mut writer = Vec::<u8>::new();
-    //     {
-    //         let mut interp = Interpreter::new(&mut reader, &mut writer);
-    //         interp.load(Program::from_source("+[>-.]"));
-    //         interp.run().unwrap();
-    //     }
-    //     assert_eq!(writer.len(), 30000);
-    // }
-    //
-    // #[test]
-    // fn ub_decrement_value_below_min() {
-    //     // Decrementing a value below it's minimum value should wrap to
-    //     // it's maximum value.
-    //     let mut reader = &[][..];
-    //     let mut writer = Vec::<u8>::new();
-    //     {
-    //         let mut interp = Interpreter::new(&mut reader, &mut writer);
-    //         interp.load(Program::from_source("-."));
-    //         interp.run().unwrap();
-    //     }
-    //     assert_eq!(writer, [255]);
-    // }
-    //
-    // #[test]
-    // fn ub_increment_value_above_max() {
-    //     // Incrementing a value above it's maximum value should wrap to
-    //     // it's minimum value.
-    //     let mut reader = &[][..];
-    //     let mut writer = Vec::<u8>::new();
-    //     {
-    //         let mut interp = Interpreter::new(&mut reader, &mut writer);
-    //         interp.load(Program::from_source("+[+]."));
-    //         interp.run().unwrap();
-    //     }
-    //     assert_eq!(writer, [0]);
-    // }
->>>>>>> Starting wrap checking.
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,11 +47,15 @@ mod instruction;
 /// Brainfuck programs are the best kind of programs too!
 mod program;
 
+/// Brainfuck programs have the best underlying data structure.
+mod tape;
+
 // Re-exports.
 pub use error::Error;
 pub use interpreter::Interpreter;
 pub use instruction::Instruction;
 pub use program::Program;
+pub use tape::Tape;
 
 pub fn eval(program: Program) -> Result<(), Error> {
     let mut stdin = io::stdin();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub fn eval(program: Program) -> Result<(), Error> {
 }
 
 pub fn eval_string(source: &str) -> Result<(), Error> {
-    let program = Program::from_source(source);
+    let program = Program::parse(source);
     eval(program)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 //! [control-flow]: enum.Instruction.html#control-flow
 //! [instruction-docs]: enum.Instruction.html
 //! [portabiliy]: http://www.muppetlabs.com/%7Ebreadbox/bf/standards.html
+#![feature(op_assign_traits, augmented_assignments)]
 #![deny(warnings)]
 
 use std::io;

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -1,0 +1,45 @@
+use super::Error;
+
+pub struct Tape {
+    cells: [u8; 30000],
+    ptr: usize,
+}
+
+impl Tape {
+    pub fn new() -> Tape {
+        Tape {
+            cells: [0; 30000],
+            ptr: 0,
+        }
+    }
+
+    pub fn get_value(&self) -> &u8 {
+        self.cells.get(self.ptr).expect("ptr must be in range.")
+    }
+
+    pub fn set_value(&mut self, value: u8) -> Result<(), Error> {
+        self.cells[self.ptr] = value;
+        Ok(())
+    }
+
+    pub fn shift_value(&mut self, amount: i16) -> Result<(), Error> {
+        self.cells[self.ptr] = (self.cells[self.ptr] as i16 + amount) as u8;
+        Ok(())
+    }
+
+    pub fn shift_ptr(&mut self, amount: i16) -> Result<(), Error> {
+        let wrapped = if amount < 0 {
+            (self.ptr as i16 + amount + 30000) % 30000
+        } else {
+            (self.ptr as i16 + amount) % 30000
+        };
+        self.ptr = wrapped as usize;
+        Ok(())
+    }
+}
+
+impl Default for Tape {
+    fn default() -> Tape {
+        Tape::new()
+    }
+}

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -1,5 +1,12 @@
 use super::Error;
 
+/// A fixed length data structure for holding bytes and a pointer.
+///
+/// The tape consists of a fixed array of bytes, and a pointer into the
+/// array. The pointer is guerenteed to be in the range of the array, so
+/// lookups can be done unconditionally.
+///
+/// TODO: Overflows should cause `Err` results.
 pub struct Tape {
     cells: [u8; 30000],
     ptr: usize,

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -24,9 +24,8 @@ impl Tape {
         *self.cells.get(self.ptr).expect("ptr must be in range.")
     }
 
-    pub fn set_value(&mut self, value: u8) -> Result<(), Error> {
+    pub fn set_value(&mut self, value: u8) {
         self.cells[self.ptr] = value;
-        Ok(())
     }
 
     pub fn shift_value(&mut self, amount: i16) -> Result<(), Error> {
@@ -63,14 +62,14 @@ mod tests {
     #[test]
     fn set_value() {
         let mut tape = Tape::new();
-        tape.set_value(20).unwrap();
+        tape.set_value(20);
         assert_eq!(tape.get_value(), 20);
     }
 
     #[test]
     fn shift_value() {
         let mut tape = Tape::new();
-        tape.set_value(5).unwrap();
+        tape.set_value(5);
         tape.shift_value(1).unwrap();
         assert_eq!(tape.get_value(), 6);
     }

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -13,8 +13,8 @@ impl Tape {
         }
     }
 
-    pub fn get_value(&self) -> &u8 {
-        self.cells.get(self.ptr).expect("ptr must be in range.")
+    pub fn get_value(&self) -> u8 {
+        *self.cells.get(self.ptr).expect("ptr must be in range.")
     }
 
     pub fn set_value(&mut self, value: u8) -> Result<(), Error> {
@@ -38,8 +38,44 @@ impl Tape {
     }
 }
 
-impl Default for Tape {
-    fn default() -> Tape {
-        Tape::new()
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new() {
+        let _ = Tape::new();
+    }
+
+    #[test]
+    fn get_value() {
+        let tape = Tape::new();
+        assert_eq!(tape.get_value(), 0);
+    }
+
+    #[test]
+    fn set_value() {
+        let mut tape = Tape::new();
+        tape.set_value(20).unwrap();
+        assert_eq!(tape.get_value(), 20);
+    }
+
+    #[test]
+    fn shift_value() {
+        let mut tape = Tape::new();
+        tape.set_value(5).unwrap();
+        tape.shift_value(1).unwrap();
+        assert_eq!(tape.get_value(), 6);
+    }
+
+    #[test]
+    fn shift_ptr() {
+        let mut tape = Tape::new();
+        tape.shift_value(4).unwrap();
+        tape.shift_ptr(1).unwrap();
+        tape.shift_value(7).unwrap();
+        assert_eq!(tape.get_value(), 7);
+        tape.shift_ptr(-1).unwrap();
+        assert_eq!(tape.get_value(), 4);
     }
 }


### PR DESCRIPTION
This implements the abstraction of a tape. Currently this undoes some of the overflowing work but things are still checked, just the errors are `panic`s now. See #16 for more discussion on what we want to do exactly about overflows.

The tape uses overloaded operators as it's primary interface. For example:

``` rust
let mut tape = Tape::new();
tape += 1;
tape >>= 1;
tape += 2;
tape <<= 1;
tape -= 1;
tape >>= 2;
*tape = 42;
println!("{}", *tape);
```

Fixes #15
