### PR TITLE
Adds Mod256ArrayTape, for wrapping + and -

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+Cargo.lock

--- a/src/tape/mod.rs
+++ b/src/tape/mod.rs
@@ -8,6 +8,7 @@ pub const TAPE_LENGTH: usize = 30000;
 pub use self::error::Error;
 pub use self::vec_tape::VecTape;
 pub use self::array_tape::ArrayTape;
+pub use self::mod256_array_tape::Mod256ArrayTape;
 
 /// An interface for the underlying data for brainfuck. Tapes are
 /// conceptually a sequential list of cells, who's values can be
@@ -105,3 +106,6 @@ mod vec_tape;
 
 /// A `[]` (array) based tape.
 mod array_tape;
+
+/// A `[]` (array) based tape that does arithmetic mod 256.
+mod mod256_array_tape;

--- a/src/tape/mod256_array_tape.rs
+++ b/src/tape/mod256_array_tape.rs
@@ -1,0 +1,78 @@
+use std::ops;
+use super::*;
+
+/// A tape with statically allocated cells.
+///
+/// This tape is implemented with a `[u8]` so it uses the memory for all
+/// 30,000 cells all the time, but allocation is done up front. The cells
+/// are of type `u8`, and the tape's length is forced to be no greater
+/// than `TAPE_LENGTH` so this tape is *nice*.
+pub struct Mod256ArrayTape {
+    cells: [u8; TAPE_LENGTH],
+    ptr: usize,
+}
+
+impl Default for Mod256ArrayTape {
+    fn default() -> Self {
+        Mod256ArrayTape {
+            cells: [0; TAPE_LENGTH],
+            ptr: 0,
+        }
+    }
+}
+
+impl Tape for Mod256ArrayTape {
+    type Cell = u8;
+
+    fn is_nice() -> bool {
+        true
+    }
+
+    fn inc_val(&mut self) -> Result<Self::Cell, Error> {
+        let v = self.wrapping_add(1);
+        **self = v;
+        Ok(v)
+    }
+
+    fn dec_val(&mut self) -> Result<Self::Cell, Error> {
+        let v = self.wrapping_sub(1);
+        **self = v;
+        Ok(v)
+    }
+
+    fn inc_ptr(&mut self) -> Result<usize, Error> {
+        match self.ptr.checked_add(1) {
+            Some(v) if v < TAPE_LENGTH => {
+                self.ptr = v;
+                Ok(v)
+            },
+            _ => Err(Error::PtrOverflow),
+        }
+    }
+
+    fn dec_ptr(&mut self) -> Result<usize, Error> {
+        match self.ptr.checked_sub(1) {
+            Some(v) if v < TAPE_LENGTH => {
+                self.ptr = v;
+                Ok(v)
+            },
+            _ => Err(Error::PtrUnderflow),
+        }
+    }
+}
+
+impl ops::Deref for Mod256ArrayTape {
+    type Target = u8;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cells[self.ptr]
+    }
+}
+
+impl ops::DerefMut for Mod256ArrayTape {
+    fn deref_mut(&mut self) -> &mut u8 {
+        &mut self.cells[self.ptr]
+    }
+}
+
+tape_tests!(Mod256ArrayTape);


### PR DESCRIPTION
One of the benchmarks I'm using, [factor](https://github.com/eliben/code-for-blog/blob/master/2017/bfjit/tests/testcases/factor.bf), depends on + and - doing arithmetic modulo 256 rather than errors. This pull request adds a Tape instance Mod256ArrayTape that implements this behavior.